### PR TITLE
Disambiguate Query Parameter Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module.exports = {
 };
 ```
 
-See the [LESS documentation](http://lesscss.org/usage/#command-line-usage-options) for all available options. LESS translates dash-case to camelCase.
+See the [LESS documentation](http://lesscss.org/usage/#command-line-usage-options) for all available options. LESS translates dash-case to camelCase. Certain options which take values (e.g. `lessc --modify-var="a=b"`) are better handled with the [JSON loader syntax](http://webpack.github.io/docs/using-loaders.html#query-parameters) (`style!css!less?{"modifyVars":{"a":"b"}}`).  
 
 ### LESS plugins
 


### PR DESCRIPTION
There are certain options on `lessc` which don't precisely map to the implied syntax in the docs (e.g. `lessc --modifyVar="myVar=myVal"` actually maps to `style!css!less?{"modifyVars":{"myVar":"myVal"}}`). This update clarifies the documentation.