### PR TITLE
Enable interpolation on modifyVars and globalVars

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,8 @@ module.exports = function(source) {
 	}
 
 	// Perform name interpolation on any variables given
-	interpolateVariables(loaderContext, config.modifyVars);
-	interpolateVariables(loaderContext, config.globalVars);
+	interpolateVariables(loaderContext, config.modifyVars, this.options);
+	interpolateVariables(loaderContext, config.globalVars, this.options);
 
 	less.render(source, config, function(e, result) {
 		var parsedMap;
@@ -185,13 +185,18 @@ function formatLessRenderError(e) {
 	return err;
 }
 
-function interpolateVariables(context, variables) {
+function interpolateVariables(context, variables, options) {
 	if (!variables) return;
 
-	console.log('context:', context);
-	console.log('variables:', variables);
+	options = options || {};
 
 	Object.keys(variables).forEach(function(variable) {
-		variables[variable] = loaderUtils.interpolateName(context, variables[variable], {});	
+		var name = loaderUtils.interpolateName(context, variable, options);
+
+		if (name !== variable) {
+			variables[name] = variables[variable];
+			delete variables[variable];
+		}
+
 	});
 }

--- a/index.js
+++ b/index.js
@@ -194,8 +194,9 @@ function interpolateVariables(context, variables, options) {
 		var name  = loaderUtils.interpolateName(context, variable, options);
 		var value = loaderUtils.interpolateName(context, variables[variable], options);
 
+		variables[name] = value;
+
 		if (name !== variable) {
-			variables[name] = value;
 			delete variables[variable];
 		}
 

--- a/index.js
+++ b/index.js
@@ -191,10 +191,11 @@ function interpolateVariables(context, variables, options) {
 	options = options || {};
 
 	Object.keys(variables).forEach(function(variable) {
-		var name = loaderUtils.interpolateName(context, variable, options);
+		var name  = loaderUtils.interpolateName(context, variable, options);
+		var value = loaderUtils.interpolateName(context, variables[variable], options);
 
 		if (name !== variable) {
-			variables[name] = variables[variable];
+			variables[name] = value;
 			delete variables[variable];
 		}
 

--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@ module.exports = function(source) {
 		};
 	}
 
+	// Perform name interpolation on any variables given
+	interpolateVariables(loaderContext, config.modifyVars);
+	interpolateVariables(loaderContext, config.globalVars);
+
 	less.render(source, config, function(e, result) {
 		var parsedMap;
 		var cb = finalCb;
@@ -179,4 +183,15 @@ function formatLessRenderError(e) {
 	);
 	err.hideStack = true;
 	return err;
+}
+
+function interpolateVariables(context, variables) {
+	if (!variables) return;
+
+	console.log('context:', context);
+	console.log('variables:', variables);
+
+	Object.keys(variables).forEach(function(variable) {
+		variables[variable] = loaderUtils.interpolateName(context, variables[variable], {});	
+	});
 }

--- a/test/css/interpolate-globalVars.css
+++ b/test/css/interpolate-globalVars.css
@@ -1,0 +1,3 @@
+div {
+	display: block;
+}

--- a/test/css/interpolate-globalVars.css
+++ b/test/css/interpolate-globalVars.css
@@ -1,3 +1,4 @@
 div {
   display: block;
+  color: red;
 }

--- a/test/css/interpolate-globalVars.css
+++ b/test/css/interpolate-globalVars.css
@@ -1,3 +1,3 @@
 div {
-	display: block;
+  display: block;
 }

--- a/test/css/interpolate-modifyVars.css
+++ b/test/css/interpolate-modifyVars.css
@@ -1,0 +1,3 @@
+div {
+	display: block;
+}

--- a/test/css/interpolate-modifyVars.css
+++ b/test/css/interpolate-modifyVars.css
@@ -1,3 +1,3 @@
 div {
-	display: block;
+  display: block;
 }

--- a/test/css/interpolate-modifyVars.css
+++ b/test/css/interpolate-modifyVars.css
@@ -1,3 +1,4 @@
 div {
   display: block;
+  position: relative;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,6 +33,12 @@ describe("less-loader", function() {
 	test("should transform urls", "url-path");
 	test("should transform urls to files above the current directory", "folder/url-path");
 	test("should transform urls to files above the sibling directory", "folder2/url-path");
+	test("should interpolate modifyVars arguments", "interpolate-modifyVars", { 
+		query: "?{'modifyVars':{'[name]':'block'}}"
+	});
+	test("should interpolate globalVars arguments", "interpolate-globalVars", { 
+		query: "?{'globalVars':{'[name]':'block'}}"
+	});
 	test("should generate source-map", "source-map", {
 		query: "?sourceMap",
 		devtool: "source-map"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,10 +34,10 @@ describe("less-loader", function() {
 	test("should transform urls to files above the current directory", "folder/url-path");
 	test("should transform urls to files above the sibling directory", "folder2/url-path");
 	test("should interpolate modifyVars arguments", "interpolate-modifyVars", { 
-		query: "?{'modifyVars':{'[name]':'block'}}"
+		query: "?{'modifyVars':{'[name]':'block','override':'relative'}}"
 	});
 	test("should interpolate globalVars arguments", "interpolate-globalVars", { 
-		query: "?{'globalVars':{'[name]':'block'}}"
+		query: "?{'globalVars':{'[name]':'block','global':'red'}}"
 	});
 	test("should generate source-map", "source-map", {
 		query: "?sourceMap",

--- a/test/less/interpolate-globalVars.less
+++ b/test/less/interpolate-globalVars.less
@@ -1,3 +1,4 @@
 div {
 	display: @interpolate-globalVars;
+	color: @global;
 }

--- a/test/less/interpolate-globalVars.less
+++ b/test/less/interpolate-globalVars.less
@@ -1,0 +1,3 @@
+div {
+	display: @interpolate-globalVars;
+}

--- a/test/less/interpolate-modifyVars.less
+++ b/test/less/interpolate-modifyVars.less
@@ -1,0 +1,3 @@
+div {
+	display: @interpolate-modifyVars;
+}

--- a/test/less/interpolate-modifyVars.less
+++ b/test/less/interpolate-modifyVars.less
@@ -1,3 +1,6 @@
+@override: absolute;
+
 div {
 	display: @interpolate-modifyVars;
+	position: @override;
 }


### PR DESCRIPTION
This PR is intended to address #69.

Ultimately we want to be able to add name interpolation to the less-loader. 

```
 module: {
    loaders: [
      {
        test: /\.less$/,
        loader: ExtractTextPlugin.extract(
          'css?sourceMap!less?{"sourceMap":"", "modifyVars":{"chunk":"[name]"}}'
        )
      }
    ]
  }
```

In this example if there was a chunk called `app` then each less file would get a variable like `@chunk: app` defined at the end of the file. 