### PR TITLE
Fix source map missing path information

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,16 +67,6 @@ module.exports = function(source) {
 		finalCb = null;
 		if(e) return cb(formatLessRenderError(e));
 
-		if (result.map) {
-			parsedMap = JSON.parse(result.map);
-
-			parsedMap.sources = parsedMap.sources.map(function(file) {
-				return path.basename(file);
-			});
-
-			result.map = JSON.stringify(parsedMap);
-		}
-
 		cb(null, result.css, result.map);
 	});
 };


### PR DESCRIPTION
Path information was lost from the source map due to `path.basename()` being run for each file in the source map. I'm not sure why this piece of code was there, but everything seems to be working fine after removing it.

Here's how the source map generated by `npm run test-source-map` looks now in Chrome developer tools:

Before:
![nayttokuva 2016-01-05 kello 14 16 25](https://cloud.githubusercontent.com/assets/250983/12115037/738bf338-b3b7-11e5-93d5-59a9381f9b35.png)

After:
![nayttokuva 2016-01-05 kello 14 16 20](https://cloud.githubusercontent.com/assets/250983/12115038/77753b94-b3b7-11e5-8e24-4fda3d1ea7e5.png)
