### PR TITLE
Missing comma in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module.exports = {
         test: /\.less$/,
         use: [
           'style-loader',
-          { loader: 'css-loader', options: { importLoaders: 1 } }
+          { loader: 'css-loader', options: { importLoaders: 1 } },
           'less-loader'
         ]
       }


### PR DESCRIPTION
Just added the comma for the "copy/paste" code warriors. :)