### PR TITLE
fix obviously missing comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ module.exports = {
             {
               loader: 'css-loader',
               options: { sourceMap: true, importLoaders: 1 }
-            }
+            },
             {
               loader: 'less-loader',
               options: { sourceMap: true }


### PR DESCRIPTION
file change:
./README.md

updates:
fix obviously missing comma in README document