### PR TITLE
test: cover more module types with the built-in CSS support

### DIFF
--- a/test/__snapshots__/built-in-css.test.js.snap
+++ b/test/__snapshots__/built-in-css.test.js.snap
@@ -16,11 +16,45 @@ exports[`built-in CSS support > should emit assets from \`url()\` 2`] = `
 []
 `;
 
+exports[`built-in CSS support > should emit less warning as webpack warning 1`] = `
+[
+  "ModuleWarning: Module Warning (from \`replaced original path\`):\\nWARNING: extend ' .body1' has no matches"
+]
+`;
+
+exports[`built-in CSS support > should emit less warning as webpack warning 2`] = `
+[]
+`;
+
 exports[`built-in CSS support > should generate source maps 1`] = `
 []
 `;
 
 exports[`built-in CSS support > should generate source maps 2`] = `
+[]
+`;
+
+exports[`built-in CSS support > should not treat a file as a CSS module with the \`css\` type 1`] = `
+".box {\\n  color: #fe33ac;\\n}\\n.nested {\\n  color: #fe33ac;\\n  padding: 10px;\\n}\\n\\n"
+`;
+
+exports[`built-in CSS support > should not treat a file as a CSS module with the \`css\` type 2`] = `
+[]
+`;
+
+exports[`built-in CSS support > should not treat a file as a CSS module with the \`css\` type 3`] = `
+[]
+`;
+
+exports[`built-in CSS support > should treat any file as a CSS module with the \`css/module\` type 1`] = `
+".built-in-css_basic_less-imported {\\n  color: hotpink;\\n}\\n.built-in-css_basic_less-modules-dir-some-module {\\n  color: hotpink;\\n}\\n.built-in-css_basic_less-box {\\n  color: #fe33ac;\\n  border-color: #fdcdea;\\n  background: url(circle.svg);\\n}\\n\\n"
+`;
+
+exports[`built-in CSS support > should treat any file as a CSS module with the \`css/module\` type 2`] = `
+[]
+`;
+
+exports[`built-in CSS support > should treat any file as a CSS module with the \`css/module\` type 3`] = `
 []
 `;
 

--- a/test/built-in-css.test.js
+++ b/test/built-in-css.test.js
@@ -55,6 +55,35 @@ describe("built-in CSS support", { timeout: 30000 }, () => {
     t.assert.snapshot(getErrors(stats));
   });
 
+  it("should not treat a file as a CSS module with the `css` type", async (t) => {
+    const testId = "./built-in-css/style.module.less";
+    const compiler = getCssCompiler(testId, {}, { type: "css" });
+    const stats = await compile(compiler);
+    const css = readAsset("main.css", compiler, stats);
+
+    assert.match(css, /^\.box\b/m, "Expected local class names to be kept");
+    t.assert.snapshot(css);
+    t.assert.snapshot(getWarnings(stats));
+    t.assert.snapshot(getErrors(stats));
+  });
+
+  it("should treat any file as a CSS module with the `css/module` type", async (t) => {
+    const testId = "./built-in-css/basic.less";
+    const compiler = getCssCompiler(testId, {}, { type: "css/module" });
+    const stats = await compile(compiler);
+    const css = readAsset("main.css", compiler, stats);
+
+    assert.doesNotMatch(
+      css,
+      /^\.box\b/m,
+      "Expected local class names to be renamed",
+    );
+    assert.match(css, /^\.[\w-]+-box\b/m);
+    t.assert.snapshot(css);
+    t.assert.snapshot(getWarnings(stats));
+    t.assert.snapshot(getErrors(stats));
+  });
+
   it("should work with the `lessOptions` option", async (t) => {
     const testId = "./built-in-css/variables.less";
     const compiler = getCssCompiler(testId, {
@@ -100,6 +129,15 @@ describe("built-in CSS support", { timeout: 30000 }, () => {
       true,
       "Expected the source map to contain the original Less source",
     );
+    t.assert.snapshot(getWarnings(stats));
+    t.assert.snapshot(getErrors(stats));
+  });
+
+  it("should emit less warning as webpack warning", async (t) => {
+    const testId = "./warn.less";
+    const compiler = getCssCompiler(testId);
+    const stats = await compile(compiler);
+
     t.assert.snapshot(getWarnings(stats));
     t.assert.snapshot(getErrors(stats));
   });

--- a/test/helpers/getCssCompiler.js
+++ b/test/helpers/getCssCompiler.js
@@ -11,10 +11,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * (i.e. `experiments.css`) instead of `css-loader`/`style-loader`.
  * @param {string} fixture fixture
  * @param {object} loaderOptions loader options
- * @param {object} config webpack config
+ * @param {object} config webpack config, the `type` property is used as the module type of the rule
  * @returns {Compiler} compiler
  */
 export default (fixture, loaderOptions = {}, config = {}) => {
+  const { type = "css/auto", ...webpackConfig } = config;
   const fullConfig = {
     mode: "development",
     devtool: config.devtool || false,
@@ -36,7 +37,7 @@ export default (fixture, loaderOptions = {}, config = {}) => {
       rules: [
         {
           test: /\.less$/i,
-          type: "css/auto",
+          type,
           use: [
             {
               loader: path.resolve(__dirname, "../../src/index.js"),
@@ -47,7 +48,7 @@ export default (fixture, loaderOptions = {}, config = {}) => {
       ],
     },
     plugins: [],
-    ...config,
+    ...webpackConfig,
   };
 
   const compiler = webpack(fullConfig);


### PR DESCRIPTION
## Summary

Follow-up to #609, rebased on top of it. The README rewrite and the tests that #609 already landed are dropped from this branch, leaving only the additional coverage.

`getCssCompiler` hardcoded `type: "css/auto"` on the rule, so only that module type could be exercised. The helper now takes the module `type` from its config argument (still defaulting to `css/auto`), which makes the other types testable.

## New tests

- **`css` type** — a `*.module.less` file compiled with `type: "css"` keeps its local class names, i.e. it is not treated as a CSS module because of its name.
- **`css/module` type** — a file without `.module` in its name compiled with `type: "css/module"` has its local class names renamed.
- **Less warnings** — a `Less` warning is reported as a webpack warning under the built-in CSS support (#609 covers errors, not warnings).

The suite is green at 143 tests, as are `npm run lint` and `npm run build`.
